### PR TITLE
Drop unused imports warnings: pylint

### DIFF
--- a/samsa/kafka/consumers.py
+++ b/samsa/kafka/consumers.py
@@ -4,7 +4,7 @@ import random
 
 from typing import List, Callable, Any
 
-from confluent_kafka import Consumer, Producer, KafkaError
+from confluent_kafka import Consumer, KafkaError
 
 logger = logging.getLogger(__name__)
 

--- a/samsa/kafka/producers.py
+++ b/samsa/kafka/producers.py
@@ -3,7 +3,6 @@ Kafka producer.
 """
 import logging
 from confluent_kafka import Producer
-import ujson as json
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Reported by pylint:
* samsa/kafka/consumers.py:7:0: W0611: Unused Producer imported from confluent_kafka (unused-import)
* samsa/kafka/producers.py:6:0: W0611: Unused ujson imported as json (unused-import)